### PR TITLE
feat: implement `options` property for status sensor

### DIFF
--- a/custom_components/cloudflare_tunnel_monitor/sensor.py
+++ b/custom_components/cloudflare_tunnel_monitor/sensor.py
@@ -2,6 +2,7 @@ import logging
 import aiohttp
 import asyncio
 import async_timeout
+from homeassistant.components.sensor import SensorEntity, SensorDeviceClass
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.helpers.entity import Entity
 from homeassistant.exceptions import PlatformNotReady
@@ -83,7 +84,7 @@ class CloudflareTunnelsDevice(Entity):
             "manufacturer": "Cloudflare",
         }
 
-class CloudflareTunnelSensor(Entity):
+class CloudflareTunnelSensor(SensorEntity):
     """Representation of a Cloudflare tunnel sensor."""
 
     def __init__(self, tunnel, coordinator, device):
@@ -111,6 +112,16 @@ class CloudflareTunnelSensor(Entity):
     def icon(self):
         """Return the icon of the sensor."""
         return 'mdi:cloud-check' if self._tunnel['status'] == 'healthy' else 'mdi:cloud-off-outline'
+
+    @property
+    def options(self):
+        """Return the possible values of the sensor."""
+        return ["inactive", "degraded", "healthy", "down"]
+
+    @property
+    def device_class(self):
+        """Return the device class of the sensor."""
+        return SensorDeviceClass.ENUM
 
     @property
     def device_info(self):


### PR DESCRIPTION
Implements the `options` property in the sensors. This helps setting up automations because the HA UI auto-completes from the possible values.

![image](https://github.com/deadbeef3137/ha-cloudflare-tunnel-monitor/assets/13923364/7f915227-abe8-4558-85c1-804f4df501d9)

![image](https://github.com/deadbeef3137/ha-cloudflare-tunnel-monitor/assets/13923364/dbcb7747-1015-48c2-af20-6b14a03222ed)
