### PR TITLE
Update to use refresh instead of request refresh

### DIFF
--- a/custom_components/cloudflare_tunnel_monitor/sensor.py
+++ b/custom_components/cloudflare_tunnel_monitor/sensor.py
@@ -139,7 +139,7 @@ class CloudflareTunnelSensor(SensorEntity):
     async def async_update(self):
         """Update the state of the sensor."""
         _LOGGER.debug(f"Requesting refresh for tunnel {self._tunnel['id']}")
-        await self.coordinator.async_request_refresh()
+        await self.coordinator.async_refresh()
         if self.coordinator.data is not None:
             _LOGGER.debug(f"Coordinator data is not None. Searching for updated tunnel data for {self._tunnel['id']}")
 


### PR DESCRIPTION
Updated async_update function to use async_refresh instead of async_request_refresh to ensure it's always looking at the latest data.